### PR TITLE
Fix or disable new compiler warnings in gcc 6+ and 7+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,12 @@ SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -fno-omit-frame-pointer")
 IF(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.3)
     SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -Wno-missing-field-initializers")
 ENDIF()
+IF(CMAKE_COMPILER_IS_GNUCC AND (
+        CMAKE_C_COMPILER_VERSION VERSION_EQUAL 6.0.0
+        OR
+        CMAKE_C_COMPILER_VERSION VERSION_GREATER 6))
+    SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -Wno-misleading-indentation")
+ENDIF()
 IF(DEVEL_MODE EQUAL 1)
     SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -O0 -g3")
     # -Werror is used to force us to fix warnings early.

--- a/src/liblsquic/lsquic_chsk_stream.c
+++ b/src/liblsquic/lsquic_chsk_stream.c
@@ -117,6 +117,7 @@ hsk_client_on_read (lsquic_stream_t *stream, struct lsquic_stream_ctx *sh)
         break;
     default:
         LSQ_WARN("lsquic_enc_session_handle_chlo_reply returned unknown value %d", s);
+        /* fallthru */
     case DATA_FORMAT_ERROR:
         LSQ_INFO("lsquic_enc_session_handle_chlo_reply returned an error");
         c_hsk->buf_in = NULL;

--- a/src/liblsquic/lsquic_frame_reader.c
+++ b/src/liblsquic/lsquic_frame_reader.c
@@ -422,6 +422,7 @@ prepare_for_payload (struct lsquic_frame_reader *fr)
             fr->fr_state.payload_length);
         fr->fr_callbacks->frc_on_error(fr->fr_cb_ctx, stream_id,
                                                 FR_ERR_HEADERS_TOO_LARGE);
+        /* fallthru */
     continue_skipping:
     default:
         fr->fr_state.by_type.skip_state.n_skipped = 0;


### PR DESCRIPTION
This addresses issue #23.