### PR TITLE
[BUGFIX] Fix libevent build error on Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,7 @@ link_directories( ${BORINGSSL_LIB}  )
 
 SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories( include )
-
-IF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+IF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     # Find libevent on FreeBSD:
     include_directories( /usr/local/include )
     link_directories( /usr/local/lib )


### PR DESCRIPTION
/home/zhangchi09/develop/lsquic-client/test/prog.c:19:26: fatal error: event2/event.h: No such file or directory
compilation terminated.
CMakeFiles/http_client.dir/build.make:86: recipe for target 'CMakeFiles/http_client.dir/test/prog.c.o' failed
make[2]: *** [CMakeFiles/http_client.dir/test/prog on.c.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/http_client.dir/all' failed
make[1]: *** [CMakeFiles/http_client.dir/all] Error 2
Makefile:94: recipe for target 'all' failed
make: *** [all] Error 2

To fix build error on MAC